### PR TITLE
[Fix] ssr의 프리렌더 과정에서 browser의 전역 객체를 참조해서 발생하는 오류 수정

### DIFF
--- a/src/app/interview-setup/page.tsx
+++ b/src/app/interview-setup/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import InterviewSettingBox from "./components/InterviewSettingBox";
 import TopNav from "./components/TopNav";
 import ReactDOM from "react-dom";
@@ -9,40 +9,47 @@ import InterviewSettingModal from "./components/InterviewSettingModal";
 
 const Page = () => {
   const [isModal, setIsModal] = useState<boolean>(false);
+  const [mounted, setMounted] = useState(false);
 
-  const portal = ReactDOM.createPortal(
-    <AnimatePresence>
-      {isModal && (
-        <>
-          <motion.div
-            key="backdrop"
-            className="fixed inset-0 bg-black z-[999]"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 0.5 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            onClick={() => setIsModal(false)}
-          />
-          <motion.div
-            key="panel"
-            className="fixed top-1/2 left-1/2 
+  useEffect(() => {
+    setMounted(true); // ✅ 브라우저에서만 true
+  }, []);
+
+  const portal =
+    mounted &&
+    ReactDOM.createPortal(
+      <AnimatePresence>
+        {isModal && (
+          <>
+            <motion.div
+              key="backdrop"
+              className="fixed inset-0 bg-black z-[999]"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 0.5 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              onClick={() => setIsModal(false)}
+            />
+            <motion.div
+              key="panel"
+              className="fixed top-1/2 left-1/2 
     -translate-x-1/2 -translate-y-1/2
     bg-white rounded-2xl shadow-xl
     w-[80%] sm:w-full h-[17rem] max-w-md p-4
     z-[1000]"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ type: "spring", stiffness: 300, damping: 30 }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <InterviewSettingModal setIsModal={setIsModal} />
-          </motion.div>
-        </>
-      )}
-    </AnimatePresence>,
-    document.body
-  );
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ type: "spring", stiffness: 300, damping: 30 }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <InterviewSettingModal setIsModal={setIsModal} />
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>,
+      document.body
+    );
   return (
     <div className="flex flex-col items-center justify-start gap-5 min-h-screen w-full">
       <TopNav />


### PR DESCRIPTION
## #️⃣연관된 이슈

#10 

## 📝작업 내용

* createPortal 메서드를 쓰는 과정에서 브라우저 전역 변수인 body를 참조하는데, ssr의 프리렌더 과정에서 이 body를 참조하면 서버에서 참조하는 것이므로 에러가난다
   * 따라서 useEffect를 사용해 컴포넌트가 브라우저에 마운트 된 후에 body를 참조하도록 수정하였음

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
